### PR TITLE
Repopulate design changes

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -124,6 +124,8 @@
             this.button98 = new System.Windows.Forms.Button();
             this.button99 = new System.Windows.Forms.Button();
             this.button100 = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
             this.flowLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -1584,16 +1586,37 @@
             this.button100.UseVisualStyleBackColor = false;
             this.button100.Click += new System.EventHandler(this.grid_Click);
             // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(15, 10);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(38, 15);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "label1";
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(194, 10);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(38, 15);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "label2";
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(324, 341);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.label1);
             this.Controls.Add(this.flowLayoutPanel1);
             this.Name = "Form1";
             this.Text = "Form1";
             this.flowLayoutPanel1.ResumeLayout(false);
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -1700,5 +1723,7 @@
         private Button button98;
         private Button button99;
         private Button button100;
+        private Label label1;
+        private Label label2;
     }
 }

--- a/Form1.cs
+++ b/Form1.cs
@@ -15,7 +15,7 @@ namespace GridBreaker {
         //global variables :(
         Button[] btnArray = new Button[100];
         Random random = new Random();
-        int count = 50;
+        int count = 30;
 
 
         public Form1() {
@@ -38,19 +38,24 @@ namespace GridBreaker {
                     case 10: btn.BackColor = Color.Yellow; break;
                 }
             }
+
+            label1.Text = "Refill in: " + ((count % 3)+3)+" moves";
+            label2.Text = count / 3 + "Refills remaining";
         }
 
 
         private void grid_Click(object sender, EventArgs e) {
-
-
-
-            count--;
             Button clicked = (Button)sender;
             destroy(clicked);
             adjust();
-            if (count > 0 && count%5 == 0) {
-                repopulate();
+            if (count >= 0) {
+                count--;
+                label1.Text = "Refill in: " + count % 3 + " moves";
+                if (count%3 == 0) {
+                    repopulate();
+                    label1.Text = "Refill in: " + ((count % 3) + 3) + " moves";
+                    label2.Text = count / 3 + " Refills remaining";
+                }
             }
         }
 
@@ -103,25 +108,25 @@ namespace GridBreaker {
             }
         }
 
-        private void repopulate() {
+        private void repopulate_old() {
             Boolean populating = true;
             while (populating) {
                 populating = false;
-                foreach (Button btn in btnArray) {
-                    if (btn.BackColor == Color.White) {
+                for(int i = btnArray.Length-1; i>=0; i--) {
+                    if (btnArray[i].BackColor == Color.White) {
                         populating = true;
                         int color = random.Next(1, 11);
                         switch (color) {
-                            case 1: btn.BackColor = Color.Red; break;
-                            case 2: btn.BackColor = Color.Red; break;
-                            case 3: btn.BackColor = Color.Red; break;
-                            case 4: btn.BackColor = Color.Green; break;
-                            case 5: btn.BackColor = Color.Green; break;
-                            case 6: btn.BackColor = Color.Green; break;
-                            case 7: btn.BackColor = Color.Blue; break;
-                            case 8: btn.BackColor = Color.Blue; break;
-                            case 9: btn.BackColor = Color.Blue; break;
-                            case 10: btn.BackColor = Color.Yellow; break;
+                            case 1: btnArray[i].BackColor = Color.Red; break;
+                            case 2: btnArray[i].BackColor = Color.Red; break;
+                            case 3: btnArray[i].BackColor = Color.Red; break;
+                            case 4: btnArray[i].BackColor = Color.Green; break;
+                            case 5: btnArray[i].BackColor = Color.Green; break;
+                            case 6: btnArray[i].BackColor = Color.Green; break;
+                            case 7: btnArray[i].BackColor = Color.Blue; break;
+                            case 8: btnArray[i].BackColor = Color.Blue; break;
+                            case 9: btnArray[i].BackColor = Color.Blue; break;
+                            case 10: btnArray[i].BackColor = Color.Yellow; break;
                         }
                     }
                 }
@@ -129,7 +134,7 @@ namespace GridBreaker {
         }
 
 
-        private void repopulate_Old() {
+        private void repopulate() {
             for (int i = 0; i < 10; i++) {
                 int color = random.Next(1, 11);
                 switch (color) {


### PR DESCRIPTION
Changed game logic to call repopulate every 3 turns, and to only populate 1 row of new cells rather than completely filling the board randomly. Also have a 1 turn delay to give the player a chance to plan ahead for the drop.